### PR TITLE
remove vodml version attr from previous model versions

### DIFF
--- a/src/main/resources/CAOM-2.2-vodml.xml
+++ b/src/main/resources/CAOM-2.2-vodml.xml
@@ -50,7 +50,7 @@
 *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
 *  PURPOSE.  See the GNU Affero         PARTICULIER. 
 -->
-<vo-dml:model xmlns:vo-dml="http://www.ivoa.net/xml/VODML/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema" version="1.0">
+<vo-dml:model xmlns:vo-dml="http://www.ivoa.net/xml/VODML/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema">
     <name>caom2</name>
     <description>a general purpose data model for use as the core data model of an astronomical data centre</description>
     <identifier/>

--- a/src/main/resources/CAOM-2.3-vodml.xml
+++ b/src/main/resources/CAOM-2.3-vodml.xml
@@ -50,7 +50,7 @@
 *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
 *  PURPOSE.  See the GNU Affero         PARTICULIER. 
 -->
-<vo-dml:model xmlns:vo-dml="http://www.ivoa.net/xml/VODML/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema" version="1.0">
+<vo-dml:model xmlns:vo-dml="http://www.ivoa.net/xml/VODML/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema">
     <name>caom2</name>
     <description>a general purpose data model for use as the core data model of an astronomical data centre</description>
     <identifier/>

--- a/src/main/resources/CAOM-2.4-vodml.xml
+++ b/src/main/resources/CAOM-2.4-vodml.xml
@@ -50,7 +50,7 @@
 *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
 *  PURPOSE.                             PARTICULIER. 
 -->
-<vo-dml:model xmlns:vo-dml="http://www.ivoa.net/xml/VODML/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema" version="1.0">
+<vo-dml:model xmlns:vo-dml="http://www.ivoa.net/xml/VODML/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema">
     <name>caom2</name>
     <description>a general purpose data model for use as the core data model of an astronomical data centre</description>
     <identifier/>


### PR DESCRIPTION
the published VO-DML xsd on www.ivoa.net does not include the version attribute and it is a stretch to fix in an erratum

cadc-vodml has been updated to use the published xsd